### PR TITLE
商品一覧表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :kanji_firstname, :kanji_lastname, :katakana_firstname, :katakana_lastname, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :kanji_firstname, :kanji_lastname, :katakana_firstname,
+                                             :katakana_lastname, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,18 +1,16 @@
 class ItemsController < ApplicationController
-   before_action :authenticate_user!, except: [:index, :show]
-
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    # @items = Item.all
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
     @item = Item.new
   end
 
-
   def create
-    @item =Item.new(item_params)
+    @item = Item.new(item_params)
     if @item.save
       redirect_to root_path
     else
@@ -20,11 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
-
-
   private
 
   def item_params
-    params.require(:item).permit(:name, :info, :image, :category_id, :sales_status_id, :shopping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :info, :image, :category_id, :sales_status_id, :shopping_fee_status_id, :prefecture_id,
+                                 :scheduled_delivery_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,9 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.includes(:user).order('created_at DESC')
+    @items = Item.order('created_at DESC')
+    # furimaのindexアクション内ではusersテーブルにアクセスせず、N+1問題が発生しないため,@items = Item.includes(:user).order('created_at DESC')より上記となる。
+
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,9 +11,8 @@ class Category < ActiveHash::Base
     { id: 9, name: 'スポーツ・レジャー' },
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
-    ]
- 
-   include ActiveHash::Associations
-   has_many :items
-     
-  end
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,24 +9,20 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
-  with_options presence: true, numericality:{ other_than: 1 , message: "can't be blank"} do
-    validates :category_id                
-    validates :sales_status_id         
-    validates :shopping_fee_status_id      
-    validates :prefecture_id       
-    validates :scheduled_delivery_id     
+  with_options presence: true, numericality: { other_than: 1, message: "can't be blank" } do
+    validates :category_id
+    validates :sales_status_id
+    validates :shopping_fee_status_id
+    validates :prefecture_id
+    validates :scheduled_delivery_id
   end
 
-
   with_options presence: true do
-    validates :name, length:{ maximum: 40 }
-    validates :info, length:{ maximum: 1000 }
-    validates :price, numericality:{ greater_than: 299, less_than: 10000000, message: "is out of setting range"}
+    validates :name, length: { maximum: 40 }
+    validates :info, length: { maximum: 1000 }
+    validates :price, numericality: { greater_than: 299, less_than: 10_000_000, message: 'is out of setting range' }
     validates :image
   end
 
-
   validates :price, numericality: { only_integer: true, message: 'is invalid. Input half-width characters' }
-
-
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -50,10 +50,7 @@ class Prefecture < ActiveHash::Base
     { id: 48, name: '沖縄県' }
 
   ]
- 
-   include ActiveHash::Associations
-   has_many :items
-     
-  end
 
-
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/sales_status.rb
+++ b/app/models/sales_status.rb
@@ -7,9 +7,8 @@ class SalesStatus < ActiveHash::Base
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
-    ]
- 
-   include ActiveHash::Associations
-   has_many :items
-     
-  end
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -6,8 +6,7 @@ class ScheduledDelivery < ActiveHash::Base
     { id: 4, data: '4~7日で発送' }
 
   ]
- 
-   include ActiveHash::Associations
-   has_many :items
-     
-  end
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/shopping_fee_status.rb
+++ b/app/models/shopping_fee_status.rb
@@ -3,9 +3,8 @@ class ShoppingFeeStatus < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '着払い（購入者負担）' },
     { id: 3, name: '送料込み（出品者負担）' }
-    ]
- 
-   include ActiveHash::Associations
-   has_many :items
-     
-  end
+  ]
+
+  include ActiveHash::Associations
+  has_many :items
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,6 @@ class User < ApplicationRecord
     validates :birthday
   end
 
-
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/.freeze
   validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,12 +128,14 @@
     </div>
     <ul class='item-lists'>
 
+      <%# コメントは、復習時の参考のため、残します %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%# <% @items.each do |item| %> 
+        <% @items.each do |item| %> 
+ 
+       <li class='list'>
         <%= link_to "#" do %> 
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -144,10 +146,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shopping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -156,13 +158,15 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
+      <%# コメントは、復習時の参考のため、残します %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+        <%= image_tag 'https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg', class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！
@@ -177,6 +181,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,24 +130,24 @@
 
       <%# コメントは、復習時の参考のため、残します %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-        <% @items.each do |item| %> 
- 
-       <li class='list'>
-        <%= link_to "#" do %> 
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+      <% if @items[0] != nil %>
+       <% @items.each do |item| %> 
+        <li class='list'>
+          <%= link_to "#" do %> 
+          <div class='item-img-content'>
+             <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= item.name %>
-          </h3>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
           <div class='item-price'>
             <span><%= item.price %>円<br><%= item.shopping_fee_status.name %></span>
             <div class='star-btn'>
@@ -156,15 +156,16 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
-      <% end %>
+         <% end %>
+        </li>
+       <% end %>
+
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
+    <% else %>
       <%# コメントは、復習時の参考のため、残します %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <% if @items.length == 0 %>
-      <li class='list'>
+       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag 'https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg', class: "item-img" %>
         <div class='item-info'>
@@ -180,8 +181,8 @@
           </div>
         </div>
         <% end %>
-      </li>
-      <% end %>
+       </li>
+    <% end %> 
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,5 @@ Rails.application.routes.draw do
   root to: "items#index" 
   devise_for :users
 
-  resources :items, only: [:new, :create] 
-   #差分で:index追加予定
+  resources :items, only: [:index, :new, :create] 
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,19 +1,18 @@
 FactoryBot.define do
   factory :item do
-    name {Faker::Name.name}
-    info {Faker::Lorem.sentence}
-    category_id {Faker::Number.between(from: 2, to: 11)}
-    sales_status_id {Faker::Number.between(from: 2, to: 3)}
-    shopping_fee_status_id {Faker::Number.between(from: 2, to: 3)}
-    prefecture_id {Faker::Number.between(from: 2, to: 48)}
-    scheduled_delivery_id {Faker::Number.between(from: 2, to: 4)}
-    price {Faker::Number.between(from: 300, to: 9999999)}
+    name { Faker::Name.name }
+    info { Faker::Lorem.sentence }
+    category_id { Faker::Number.between(from: 2, to: 11) }
+    sales_status_id { Faker::Number.between(from: 2, to: 3) }
+    shopping_fee_status_id { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id { Faker::Number.between(from: 2, to: 48) }
+    scheduled_delivery_id { Faker::Number.between(from: 2, to: 4) }
+    price { Faker::Number.between(from: 300, to: 9_999_999) }
 
-    association :user 
+    association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
-    
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,105 +1,97 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-
   describe '#create' do
     before do
-    @item = FactoryBot.build(:item)
+      @item = FactoryBot.build(:item)
     end
-    
+
     describe '商品の出品' do
-      context "商品が保存できる場合" do
-        it "画像と商品名と商品説明、商品の詳細（カテゴリー、商品の状態、配送料の負担、発送元の地域、発送までの日数、価格）があれば投稿できる" do
+      context '商品が保存できる場合' do
+        it '画像と商品名と商品説明、商品の詳細（カテゴリー、商品の状態、配送料の負担、発送元の地域、発送までの日数、価格）があれば投稿できる' do
           expect(@item).to be_valid
         end
       end
- 
-      context "商品が保存できない場合" do
-        it "画像がなければ、出品できない" do
+
+      context '商品が保存できない場合' do
+        it '画像がなければ、出品できない' do
           @item.image = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Image can't be blank")
         end
 
-        it "商品のカテゴリー選択がなければ、出品できない" do
+        it '商品のカテゴリー選択がなければ、出品できない' do
           @item.category_id = 1
           @item.valid?
           expect(@item.errors.full_messages).to include("Category can't be blank")
         end
 
-        it "商品の状態の説明がなければ、出品できない" do
+        it '商品の状態の説明がなければ、出品できない' do
           @item.sales_status_id = 1
           @item.valid?
           expect(@item.errors.full_messages).to include("Sales status can't be blank")
         end
 
-        it "配送料の負担説明がなければ、出品できない" do
+        it '配送料の負担説明がなければ、出品できない' do
           @item.shopping_fee_status_id = 1
           @item.valid?
           expect(@item.errors.full_messages).to include("Shopping fee status can't be blank")
         end
 
-        it "発送元地域の説明がなければ、出品できない" do
+        it '発送元地域の説明がなければ、出品できない' do
           @item.prefecture_id = 1
           @item.valid?
           expect(@item.errors.full_messages).to include("Prefecture can't be blank")
         end
 
-
-        it "発送までの日数説明がなければ、出品できない" do
+        it '発送までの日数説明がなければ、出品できない' do
           @item.scheduled_delivery_id = 1
           @item.valid?
           expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
         end
 
-
-        it "価格が空では、出品できない" do
-          @item.price = ""
+        it '価格が空では、出品できない' do
+          @item.price = ''
           @item.valid?
           expect(@item.errors.full_messages).to include("Price can't be blank")
         end
 
-        it "価格が300円より少ない場合は、出品できない" do
+        it '価格が300円より少ない場合は、出品できない' do
           @item.price = 200
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is out of setting range")
+          expect(@item.errors.full_messages).to include('Price is out of setting range')
         end
 
-        it "価格が9,999,999円より多い場合は、出品できない" do
-          @item.price = 10000000
+        it '価格が9,999,999円より多い場合は、出品できない' do
+          @item.price = 10_000_000
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is out of setting range")
+          expect(@item.errors.full_messages).to include('Price is out of setting range')
         end
 
-        it "価格が全角では出品できない" do
-          @item.price = "１０００"
+        it '価格が全角では出品できない' do
+          @item.price = '１０００'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+          expect(@item.errors.full_messages).to include('Price is invalid. Input half-width characters')
         end
 
-        it "半角英数混合では登録できないこと " do
-          @item.price = "a300"
+        it '半角英数混合では登録できないこと ' do
+          @item.price = 'a300'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+          expect(@item.errors.full_messages).to include('Price is invalid. Input half-width characters')
         end
 
-        it "半角英語だけでは登録できないこと " do
-          @item.price = "aaa"
+        it '半角英語だけでは登録できないこと ' do
+          @item.price = 'aaa'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is invalid. Input half-width characters")
+          expect(@item.errors.full_messages).to include('Price is invalid. Input half-width characters')
         end
 
-
-        it "ユーザーが紐づいていないと出品できない" do
+        it 'ユーザーが紐づいていないと出品できない' do
           @item.user = nil
           @item.valid?
-          expect(@item.errors.full_messages).to include("User must exist")
+          expect(@item.errors.full_messages).to include('User must exist')
         end
-
       end
-
     end
-
-
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe User, type: :model do
     before do
       @user = FactoryBot.build(:user)
     end
-    
+
     describe 'ユーザー新規登録' do
       context 'ユーザー登録がうまくいかない時' do
-
         it 'nicknameが空だと登録できない' do
           @user.nickname = ''
           @user.valid?
@@ -51,7 +50,6 @@ RSpec.describe User, type: :model do
           expect(@user.errors.full_messages).to include('Password Include both letters and numbers')
         end
 
-
         it 'passwordが６文字より少ない場合は登録できない' do
           @user.password = '12345'
           @user.password_confirmation = '12345'
@@ -59,16 +57,12 @@ RSpec.describe User, type: :model do
           expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
         end
 
-
-
-
         it '重複したemailが存在する場合登録できない' do
           @user.save
           another_user = FactoryBot.build(:user, email: @user.email)
           another_user.valid?
           expect(another_user.errors.full_messages).to include('Email has already been taken')
         end
-
 
         it '生年月日が空では登録できない' do
           @user.birthday = ''
@@ -101,12 +95,6 @@ RSpec.describe User, type: :model do
         end
       end
 
-
-
-
-
-
-
       context '新規登録がうまくいく時' do
         it 'nickname,email,passwordとpassword_confirmationとお名前（全角）及びお名前（カナ全角）、生年月日が存在すれば登録できること' do
           expect(@user).to be_valid
@@ -123,10 +111,6 @@ RSpec.describe User, type: :model do
           @user.password_confirmation = '123abc'
           expect(@user).to be_valid
         end
-
-
-
-
       end
     end
   end


### PR DESCRIPTION
＃what
商品一覧表示の実装

＃why
商品一覧表示のため。
（補足説明通り、「売却済みの商品は、画像上に『sold out』の文字が表示されること」は未実装です。）
（コメントは、復習時のための参考にしたいため、削除しておりません。その旨コメント残しました）

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/3314745f231f530bb5cd83133694767f

商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/68dd5f53e7bd29a1374965e91ad0ee86